### PR TITLE
Remove unused frontend API endpoints

### DIFF
--- a/Agent V2/Agent V2/script.js
+++ b/Agent V2/Agent V2/script.js
@@ -419,20 +419,5 @@ window.VlaamseCodexAPI = {
     async getAnalysis() {
         const response = await fetch('/analysis');
         return response.json();
-    },
-    
-    async getDocument(documentId) {
-        const response = await fetch(`/document/${documentId}`);
-        return response.json();
-    },
-    
-    async startConsolidation() {
-        const response = await fetch('/consolidate', { method: 'POST' });
-        return response.json();
-    },
-    
-    async getConsolidation() {
-        const response = await fetch('/consolidation');
-        return response.json();
     }
-}; 
+};


### PR DESCRIPTION
## Summary
- remove unimplemented `getDocument`, `startConsolidation`, and `getConsolidation` calls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684075850f9c83299539b740ded39439